### PR TITLE
Fix CSP for Tally.so qualification form embeds

### DIFF
--- a/public/_headers
+++ b/public/_headers
@@ -3,5 +3,5 @@
   X-Content-Type-Options: nosniff
   Referrer-Policy: strict-origin-when-cross-origin
   X-Permitted-Cross-Domain-Policies: none
-  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://andersontimana.me; connect-src 'self' https://challenges.cloudflare.com https://api.brevo.com; frame-src https://challenges.cloudflare.com; base-uri 'self'; form-action 'self';
+  Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-inline' https://challenges.cloudflare.com https://tally.so; style-src 'self' 'unsafe-inline'; img-src 'self' data: https://andersontimana.me https://tally.so; connect-src 'self' https://challenges.cloudflare.com https://api.brevo.com https://tally.so; frame-src https://challenges.cloudflare.com https://tally.so; base-uri 'self'; form-action 'self';
   Permissions-Policy: accelerometer=(), camera=(), gc=(), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), payment=(), usb=()


### PR DESCRIPTION
I have updated the `public/_headers` file to include `https://tally.so` in several Content-Security-Policy (CSP) directives. 

Specifically:
- Added `https://tally.so` to `script-src` to allow the Tally widget script (`https://tally.so/widgets/embed.js`) to load.
- Added `https://tally.so` to `frame-src` to allow the Tally forms to be rendered within iframes.
- Added `https://tally.so` to `img-src` and `connect-src` to ensure all form assets and data submissions can be handled correctly.

I've verified the changes by running a project build and checking the generated `dist/_headers` file.

Fixes #1

---
*PR created automatically by Jules for task [16115390586498653857](https://jules.google.com/task/16115390586498653857) started by @anderson-timana*